### PR TITLE
Create an abstract base class in the phy_wrapper sub-module

### DIFF
--- a/.idea/MeComPyAPI.iml
+++ b/.idea/MeComPyAPI.iml
@@ -2,6 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/src/mecompyapi/phy_wrapper/int_mecom_phy.py
+++ b/src/mecompyapi/phy_wrapper/int_mecom_phy.py
@@ -1,3 +1,6 @@
+from abc import ABC, abstractmethod
+
+
 class MeComPhyTimeoutException(Exception):
     """
     Represents timeout errors occur during data reception.
@@ -18,23 +21,28 @@ class MeComPhyInterfaceException(Exception):
         super().__init__(message)
     
 
-class IntMeComPhy:
+class IntMeComPhy(ABC):
     """
-    Sends data to the physical interface.
+    The upper communication level uses this interface 
+    to have standardized interface to the physical level.
+    The physical interface which implements this interface must already be open, 
+    before you can use functions of this interface.
     """
     def __init__(self):
         pass
-    
-    def send_string(self, stream):
+
+    @abstractmethod
+    def send_string(self, stream: str):
         """
         Sends data to the physical interface.
 
         :param stream: The whole content of the Stream is sent to the physical interface.
-        :type stream:
+        :type stream: str
         """
         raise NotImplementedError
 
-    def get_data_or_timeout(self):
+    @abstractmethod
+    def get_data_or_timeout(self, stream: str):
         """
         Tries to read data from the physical interface or throws a timeout exception.
         
@@ -42,17 +50,32 @@ class IntMeComPhy:
         If the receiving buffer is empty, it tries to read at least one byte. 
         It will wait till the timeout occurs if nothing is received.
         Must probably be called several times to receive the whole frame.
+
+        :param stream: Stream where data will be added to.
+        :type stream: str
+        :raises MeComPhyInterfaceException: Thrown when the underlying physical interface
+            is not OK.
+        :raises MeComPhyTimeoutException: Thrown when 0 bytes were received during the
+            specified timeout time.
         """
         raise NotImplementedError
-    
-    def change_speed(self):
+
+    @abstractmethod
+    def change_speed(self, baudrate: int):
         """
         Used to change the Serial Speed in case of serial communication interfaces.
+
+        :param baudrate:
+        :type baudrate: int
         """
         raise NotImplementedError
-    
-    def set_timeout(self):
+
+    @abstractmethod
+    def set_timeout(self, milliseconds: int):
         """
         Used to modify the standard timeout of the physical interface.
+
+        :param milliseconds:
+        :type milliseconds: int
         """
         raise NotImplementedError

--- a/src/mecompyapi/phy_wrapper/mecom_phy_serial_port.py
+++ b/src/mecompyapi/phy_wrapper/mecom_phy_serial_port.py
@@ -113,7 +113,7 @@ class MeComPhySerialPort(IntMeComPhy):
         # flush write cache
         self.ser.flush()
 
-    def get_data_or_timeout(self) -> str:
+    def get_data_or_timeout(self, stream: str) -> str:
         """
         Tries to read data from the physical interface or throws a timeout exception.
 
@@ -122,8 +122,12 @@ class MeComPhySerialPort(IntMeComPhy):
         It will wait till the timeout occurs if nothing is received.
         Must probably be called several times to receive the whole frame.
 
-        :raises MeComPhyTimeoutException:
-        :raises MeComPhyInterfaceException:
+        :param stream: Stream where data will be added to.
+        :type stream: str
+        :raises MeComPhyInterfaceException: Thrown when the underlying physical interface
+            is not OK.
+        :raises MeComPhyTimeoutException: Thrown when 0 bytes were received during the
+            specified timeout time.
         :return:
         :rtype: str
         """
@@ -145,3 +149,21 @@ class MeComPhySerialPort(IntMeComPhy):
 
         except Exception as e:
             raise MeComPhyInterfaceException(f"Failure during receiving: {e}")
+
+    def change_speed(self, baudrate: int):
+        """
+        Used to change the Serial Speed in case of serial communication interfaces.
+
+        :param baudrate:
+        :type baudrate: int
+        """
+        raise NotImplementedError
+
+    def set_timeout(self, milliseconds: int):
+        """
+        Used to modify the standard timeout of the physical interface.
+
+        :param milliseconds:
+        :type milliseconds: int
+        """
+        raise NotImplementedError


### PR DESCRIPTION
IntMeComPhy in the int_mecom_phy.py module changed to an abstract base class and the mecom_phy_serial_port.py module is updated accordingly.