### PR TITLE
Functionality added to TEC wrapper to control save to flash mechanism

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/examples/set_auto_save_to_flash.py
+++ b/examples/set_auto_save_to_flash.py
@@ -1,0 +1,31 @@
+import time
+import logging
+from mecompyapi.tec1090series import MeerstetterTEC, SaveToFlashState
+
+
+if __name__ == '__main__':
+    # start logging
+    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s:%(module)s:%(levelname)s:%(message)s")
+
+    # initialize controller
+    mc = MeerstetterTEC()
+
+    mc.connect(port="COM9")
+
+    identity = mc.get_id()
+    print("identity: {}".format(identity))
+    print("\n", end="")
+
+    print("status: {}".format(mc.get_device_status()))
+    print("\n", end="")
+
+    mc.reset()
+    print("status: {}".format(mc.get_device_status()))
+    time.sleep(2.0)  # Wait time of 2 seconds is required to maintain connection.
+    print("status: {}".format(mc.get_device_status()))
+    print("\n", end="")
+
+    save_to_flash_state: SaveToFlashState = mc.get_automatic_save_to_flash()
+    print("save_to_flash_state: {}".format(mc.get_automatic_save_to_flash()))
+
+    mc.tear()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mecompyapi
-version = 0.0.1
+version = 0.0.2
 author = John Houlihan
 author_email = houlihaj@uci.edu
 description = A Python API for the MeCom protocol by Meerstetter.

--- a/src/mecompyapi/phy_wrapper/int_mecom_phy.py
+++ b/src/mecompyapi/phy_wrapper/int_mecom_phy.py
@@ -42,7 +42,7 @@ class IntMeComPhy(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_data_or_timeout(self, stream: str):
+    def get_data_or_timeout(self):
         """
         Tries to read data from the physical interface or throws a timeout exception.
         
@@ -51,8 +51,6 @@ class IntMeComPhy(ABC):
         It will wait till the timeout occurs if nothing is received.
         Must probably be called several times to receive the whole frame.
 
-        :param stream: Stream where data will be added to.
-        :type stream: str
         :raises MeComPhyInterfaceException: Thrown when the underlying physical interface
             is not OK.
         :raises MeComPhyTimeoutException: Thrown when 0 bytes were received during the

--- a/src/mecompyapi/phy_wrapper/mecom_phy_serial_port.py
+++ b/src/mecompyapi/phy_wrapper/mecom_phy_serial_port.py
@@ -113,7 +113,7 @@ class MeComPhySerialPort(IntMeComPhy):
         # flush write cache
         self.ser.flush()
 
-    def get_data_or_timeout(self, stream: str) -> str:
+    def get_data_or_timeout(self) -> str:
         """
         Tries to read data from the physical interface or throws a timeout exception.
 
@@ -122,8 +122,6 @@ class MeComPhySerialPort(IntMeComPhy):
         It will wait till the timeout occurs if nothing is received.
         Must probably be called several times to receive the whole frame.
 
-        :param stream: Stream where data will be added to.
-        :type stream: str
         :raises MeComPhyInterfaceException: Thrown when the underlying physical interface
             is not OK.
         :raises MeComPhyTimeoutException: Thrown when 0 bytes were received during the

--- a/src/mecompyapi/tec1090series.py
+++ b/src/mecompyapi/tec1090series.py
@@ -87,6 +87,11 @@ class LookupTableStatus(Enum):
     SUB_TABLE_NOT_FOUND = 6
 
 
+class SaveToFlashState(Enum):
+    ENABLED = 0
+    DISABLED = 1  # all parameters are now RAM parameters
+
+
 class MeerstetterTEC(object):
     r"""
     Controlling TEC devices via serial.
@@ -227,6 +232,32 @@ class MeerstetterTEC(object):
                                                              instance=self.instance)
         status_id = DeviceStatus(status_id_int)
         return status_id
+
+    def set_automatic_save_to_flash(self, save_to_flash: SaveToFlashState) -> None:
+        """
+        Enable or disable the automatic save to flash mechanism.
+
+        :param save_to_flash: enable or disable the automatic save to flash mechanism
+        :type save_to_flash: SaveToFlashState
+        :return: None
+        """
+        logging.debug(f"set the automatic save to flash state for channel {self.instance} to {save_to_flash}")
+        self.mecom_basic_cmd.set_int32_value(address=self.address, parameter_id=108,
+                                             instance=self.instance, value=save_to_flash.value)
+
+    def get_automatic_save_to_flash(self) -> SaveToFlashState:
+        """
+        Get the automatic save to flash mechanism state.
+
+        :return: returns whether the automatic save to flash mechanism
+            is enabled or disabled
+        :rtype: SaveToFlashState
+        """
+        logging.debug(f"get the automatic save to flash state for channel {self.instance}")
+        resp = self.mecom_basic_cmd.get_int32_value(address=self.address, parameter_id=108,
+                                                    instance=self.instance)
+        save_to_flash_state = SaveToFlashState(int(resp))
+        return save_to_flash_state
 
     def get_temperature(self) -> float:
         """

--- a/src/mecompyapi/tec1090series.py
+++ b/src/mecompyapi/tec1090series.py
@@ -137,7 +137,8 @@ class MeerstetterTEC(object):
                 self.address = self.get_device_address()
                 logging.debug(f"connected to {self.address}")
                 return
-            except ComCommandException:
+            except ComCommandException as e:
+                logging.debug(f"[ComCommandException] : {e}")
                 continue
         raise InstrumentException(f"Could not successfully query the controller address after {retries} retries...")
 


### PR DESCRIPTION
Most TEC parameters are FLASH parameters and updates are written to flash after each execution. The flash can be written to only a finite number of times. By disabling the save to flash mechanism, temporary changes can be stored in the RAM rather than written to flash.