### PR TITLE
Implement set value methods in the mecom_basic_cmd.py module

### DIFF
--- a/examples/set_auto_save_to_flash.py
+++ b/examples/set_auto_save_to_flash.py
@@ -25,6 +25,8 @@ if __name__ == '__main__':
     print("status: {}".format(mc.get_device_status()))
     print("\n", end="")
 
+    mc.set_automatic_save_to_flash(save_to_flash=SaveToFlashState.DISABLED)
+
     save_to_flash_state: SaveToFlashState = mc.get_automatic_save_to_flash()
     print("save_to_flash_state: {}".format(mc.get_automatic_save_to_flash()))
 

--- a/src/mecompyapi/mecom_core/mecom_basic_cmd.py
+++ b/src/mecompyapi/mecom_core/mecom_basic_cmd.py
@@ -21,6 +21,7 @@ class MeComBasicCmd:
         # self.address = self.get_device_address()
 
     # region Misc Functions
+    # noinspection PyMethodMayBeStatic
     def get_device_address(self) -> int:
         """
         The device reacts to the following cases:
@@ -199,7 +200,19 @@ class MeComBasicCmd:
         :type value: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         """
-        raise NotImplementedError
+        mecom_var_convert = MeComVarConvert()
+        try:
+            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "VS")
+            tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
+            tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
+            tx_frame.payload = mecom_var_convert.add_int32(tx_frame.payload, value)
+            rx_frame = self.mequery_set.set(tx_frame=tx_frame)
+            return rx_frame
+
+        except Exception as e:
+            raise ComCommandException(f"Set INT32 Value failed: Address: {address}; "
+                                      f"ID: {parameter_id}; Detail: {instance} : {e}")
 
     def set_int64_value(self, address: int, parameter_id: int, instance: int, value: int):
         """
@@ -215,7 +228,19 @@ class MeComBasicCmd:
         :type value: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         """
-        raise NotImplementedError
+        mecom_var_convert = MeComVarConvert()
+        try:
+            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "VS")
+            tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
+            tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
+            tx_frame.payload = mecom_var_convert.add_int64(tx_frame.payload, value)
+            rx_frame = self.mequery_set.set(tx_frame=tx_frame)
+            return rx_frame
+
+        except Exception as e:
+            raise ComCommandException(f"Set INT64 Value failed: Address: {address}; "
+                                      f"ID: {parameter_id}; Detail: {instance} : {e}")
 
     def set_float_value(self, address: int, parameter_id: int, instance: int, value: float):
         """
@@ -242,7 +267,8 @@ class MeComBasicCmd:
             return rx_frame
 
         except Exception as e:
-            raise ComCommandException(f"Set FLOAT Value failed: {e}")
+            raise ComCommandException(f"Set FLOAT32 Value failed: Address: {address}; "
+                                      f"ID: {parameter_id}; Detail: {instance} : {e}")
 
     def set_double_value(self, address: int, parameter_id: int, instance: int, value: int):
         """
@@ -258,7 +284,19 @@ class MeComBasicCmd:
         :type value: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         """
-        raise NotImplementedError
+        mecom_var_convert = MeComVarConvert()
+        try:
+            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "VS")
+            tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
+            tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
+            tx_frame.payload = mecom_var_convert.add_double64(tx_frame.payload, value)
+            rx_frame = self.mequery_set.set(tx_frame=tx_frame)
+            return rx_frame
+
+        except Exception as e:
+            raise ComCommandException(f"Set DOUBLE64 Value failed: Address: {address}; "
+                                      f"ID: {parameter_id}; Detail: {instance} : {e}")
 
     def set_device_address(self, address: int, device_type: int, serial_number: str, set_address: int, option: int):
         """
@@ -312,10 +350,10 @@ if __name__ == "__main__":
     print(f"type(identify) : {type(identify)}")
     print("\n", end="")
 
-    device_type = mecom_basic_cmd.get_int32_value(address=2, parameter_id=100,
-                                                  instance=1)  # parameter_name : "Device Type"
-    print(f"device_type : {device_type}")
-    print(f"type(device_type) : {type(device_type)}")
+    device_type_ = mecom_basic_cmd.get_int32_value(address=2, parameter_id=100,
+                                                   instance=1)  # parameter_name : "Device Type"
+    print(f"device_type : {device_type_}")
+    print(f"type(device_type) : {type(device_type_)}")
     print("\n", end="")
 
     object_temperature = mecom_basic_cmd.get_float_value(address=2, parameter_id=1000,

--- a/src/mecompyapi/mecom_core/mecom_var_convert.py
+++ b/src/mecompyapi/mecom_core/mecom_var_convert.py
@@ -178,7 +178,7 @@ class MeComVarConvert:
         stream += '{:08X}'.format(unpack('<I', pack('<f', value))[0])
         return stream
 
-    def add_double64(self, stream, value: int) -> None:
+    def add_double64(self, stream, value: int) -> str:
         """
         Writes a DOUBLE64 (.net double) to the stream.
 
@@ -186,7 +186,8 @@ class MeComVarConvert:
         :type stream:
         :param value: Value to be added.
         :type value: int
-        :return: None
+        :return:
+        :rtype: str
         """
         raise NotImplementedError
 


### PR DESCRIPTION
The set value methods have been implemented in the mecom_basic_cmd.py module. The implementation was straight forward and no testing was performed. Will perform testing after this pull request and will create a new issue if there are problems with the implementation.