### PR TITLE
Add ability to connect using the FTDI drivers

### DIFF
--- a/examples/connect_ftdi.py
+++ b/examples/connect_ftdi.py
@@ -1,0 +1,20 @@
+import time
+import logging
+import ftd2xx
+from mecompyapi.tec1090series import MeerstetterTEC
+
+
+if __name__ == '__main__':
+    # start logging
+    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s:%(module)s:%(levelname)s:%(message)s")
+
+    # initialize controller
+    mc = MeerstetterTEC()
+
+    mc.connect_ftdi(id_str="DK0E1IDC")
+
+    identity = mc.get_id()
+    print(f"identity: {identity}")
+    print("\n", end="")
+
+    mc.tear()

--- a/examples/connect_serial_port.py
+++ b/examples/connect_serial_port.py
@@ -16,18 +16,4 @@ if __name__ == '__main__':
     print(f"identity: {identity}")
     print("\n", end="")
 
-    print(f"status: {mc.get_device_status()}")
-    print("\n", end="")
-
-    mc.reset()
-    print(f"status: {mc.get_device_status()}")
-    time.sleep(2.0)  # Wait time of 2 seconds is required to maintain connection.
-    print(f"status: {mc.get_device_status()}")
-    print("\n", end="")
-
-    settings = mc.get_all_settings()
-    print(f"settings:\n", end="")
-    for key in settings:
-        print(f"{key} : {settings[key]}")
-
     mc.tear()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyserial
 pythoncrc
+ftd2xx

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,10 @@ classifiers =
     Programming Language :: Python :: 3
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
 	License :: OSI Approved :: MIT License
 	Operating System :: Microsoft :: Windows
-	
+
 [options]
 package_dir =
 	= src
@@ -24,6 +25,7 @@ python_requires = >=3.9
 install_requires =
 	pyserial>=3.5
 	pythoncrc>=1.21
+	ftd2xx>=1.3.3
 include_package_data=True
 
 [options.packages.find]

--- a/src/mecompyapi/mecom_core/mecom_query_set.py
+++ b/src/mecompyapi/mecom_core/mecom_query_set.py
@@ -1,8 +1,11 @@
 import random
 
+from typing import Union
+
 from mecompyapi.mecom_core.mecom_frame import MeComFrame, MeComPacket, ERcvType
 from mecompyapi.phy_wrapper.int_mecom_phy import IntMeComPhy, MeComPhyTimeoutException
 from mecompyapi.phy_wrapper.mecom_phy_serial_port import MeComPhySerialPort
+from mecompyapi.phy_wrapper.mecom_phy_ftdi import MeComPhyFtdi
 
 
 class SetServerErrorException(Exception):
@@ -55,10 +58,7 @@ class MeComQuerySet:
     otherwise it will throw an exception.
     """
 
-    # sequence_number: int
-    # statistics = Statistics()
-
-    def __init__(self, phy_com: MeComPhySerialPort):
+    def __init__(self, phy_com: Union[MeComPhySerialPort, MeComPhyFtdi]):
         """
         Initializes the communication interface.
         This object can then be passed to the Command objects like MeBasicCmd.
@@ -73,13 +73,7 @@ class MeComQuerySet:
         self.is_ready = False
         self.version_is_okay = False
         self.default_device_address = 1
-        
-    # def get(self):
-    #     raise NotImplementedError
-    #
-    # def set(self):
-    #     raise NotImplementedError
-    
+
     def get_is_ready(self):
         """
         true when the interface is ready to use; false if not.
@@ -302,7 +296,8 @@ class MeComQuerySet:
             )
         if rx_frame.sequence_number != self.sequence_number:
             raise GeneralException(
-                f"Query failed : Wrong Sequence Number received. Received {rx_frame.sequence_number} ; Expected {self.sequence_number}"
+                f"Query failed : Wrong Sequence Number received. "
+                f"Received {rx_frame.sequence_number} ; Expected {self.sequence_number}"
             )
         if rx_frame.address != tx_frame.address:
             raise GeneralException(
@@ -357,7 +352,8 @@ class MeComQuerySet:
         # Communication failed, check last error
         if rx_frame.sequence_number != self.sequence_number:
             raise GeneralException(
-                f"Set failed: Wrong Sequence Number received. Received {rx_frame.sequence_number} ; Expected {self.sequence_number}"
+                f"Set failed: Wrong Sequence Number received. "
+                f"Received {rx_frame.sequence_number} ; Expected {self.sequence_number}"
             )
 
         if rx_frame.address != tx_frame.address:

--- a/src/mecompyapi/phy_wrapper/mecom_phy_ftdi.py
+++ b/src/mecompyapi/phy_wrapper/mecom_phy_ftdi.py
@@ -1,0 +1,118 @@
+import ftd2xx
+
+from mecompyapi.phy_wrapper.int_mecom_phy import (
+    IntMeComPhy, MeComPhyInterfaceException, MeComPhyTimeoutException
+)
+
+
+class MeComPhyFtdi(IntMeComPhy):
+    """
+    Implements the IMeComPhy interface for the FTDI chip drivers.
+    """
+    def __init__(self):
+        """
+        Implements the IMeComPhy interface for the FTDI chip drivers.        
+        """
+        super().__init__()
+        self.ftdi = None
+
+    def mecom_set_default_settings(self, baudrate: int):
+        """
+        Initializes the FTDI default settings, so that is it usually running
+        with Meerstetter products.
+
+        This function is not part of the IMeComPhy interface.
+        
+        :param baudrate: Baud Rate for the Serial Interface.
+        :type baudrate: int
+        """
+        raise NotImplementedError
+
+    def connect(self, id_str: str, timeout: int = 1, baudrate: int = 57600):
+        """
+        Connects to a serial port. On Windows, these are typically 'COMX' where X is the number of the port. In Linux,
+        they are often /dev/ttyXXXY where XXX usually indicates if it is a serial or USB port, and Y indicates the
+        number. E.g. /dev/ttyUSB0 on Linux and 'COM7' on Windows
+
+        :param id_str:
+        :type id_str: str
+        :param timeout: Time in seconds for read timeout. If timeout happens, read returns empty string.
+        :type timeout: int
+        :param baudrate: The baud rate setting.
+        :type baudrate: int
+        :raises SerialException:
+        :raises InstrumentConnectionError:
+        """
+        id_str_bytes: bytes = id_str.encode()
+        self.ftdi = ftd2xx.openEx(id_str=id_str_bytes)
+        self.ftdi.purge(mask=3)  # purges receive and transmit buffer in the device
+        self.ftdi.setTimeouts(read=timeout * 1000, write=timeout * 1000)
+
+    def tear(self):
+        """
+        Tear should always be called when the instrument is being disconnected. It should
+        also be called when the program is ending.
+        """
+        self.ftdi.purge(mask=3)  # purges receive and transmit buffer in the device
+        self.ftdi.close()
+
+    def send_string(self, stream: str):
+        """
+        Sends data to the physical interface.
+
+        :param stream: The whole content of the Stream is sent to the physical interface.
+        :type stream: str
+        """
+        self.ftdi.purge(mask=3)  # purges receive and transmit buffer in the device
+
+        stream_bytes = stream.encode()
+
+        self.ftdi.write(data=stream_bytes)
+
+    def get_data_or_timeout(self):
+        """
+        Tries to read data from the physical interface or throws a timeout exception.
+
+        Reads the available data in the physical interface buffer and returns immediately. 
+        If the receiving buffer is empty, it tries to read at least one byte. 
+        It will wait till the timeout occurs if nothing is received.
+        Must probably be called several times to receive the whole frame.
+
+        :raises MeComPhyInterfaceException: Thrown when the underlying physical interface
+            is not OK.
+        :raises MeComPhyTimeoutException: Thrown when 0 bytes were received during the
+            specified timeout time.
+        """
+        try:
+            # initialize response and carriage return
+            cr = "\r".encode()
+            response_frame = b''
+            response_byte = self.ftdi.read(nchars=1)  # read one byte at a time, timeout is set on instance level
+
+            # read until stop byte
+            while response_byte != cr:
+                response_frame += response_byte
+                response_byte = self.ftdi.read(nchars=1)
+
+            return response_frame.decode()
+
+        except Exception as e:
+            raise MeComPhyInterfaceException(f"Failure during receiving: {e}")
+
+    def change_speed(self, baudrate: int):
+        """
+        Used to change the Serial Speed in case of serial communication interfaces.
+
+        :param baudrate: Baud Rate for the Serial Interface.
+        :type baudrate: int
+        """
+        raise NotImplementedError
+
+    def set_timeout(self, milliseconds: int):
+        """
+        Used to modify the standard timeout of the physical interface.
+
+        :param milliseconds:
+        :type milliseconds: int
+        """
+        raise NotImplementedError

--- a/src/mecompyapi/phy_wrapper/mecom_phy_ftdi.py
+++ b/src/mecompyapi/phy_wrapper/mecom_phy_ftdi.py
@@ -1,4 +1,5 @@
 import ftd2xx
+from ftd2xx import FTD2XX
 
 from mecompyapi.phy_wrapper.int_mecom_phy import (
     IntMeComPhy, MeComPhyInterfaceException, MeComPhyTimeoutException
@@ -28,13 +29,13 @@ class MeComPhyFtdi(IntMeComPhy):
         """
         raise NotImplementedError
 
-    def connect(self, id_str: str, timeout: int = 1, baudrate: int = 57600):
+    def connect(self, id_str: str, timeout: int = 1, baudrate: int = 57600) -> None:
         """
-        Connects to a serial port. On Windows, these are typically 'COMX' where X is the number of the port. In Linux,
-        they are often /dev/ttyXXXY where XXX usually indicates if it is a serial or USB port, and Y indicates the
-        number. E.g. /dev/ttyUSB0 on Linux and 'COM7' on Windows
+        Open a handle to an usb device by serial number(default), description or
+        location(Windows only) depending on value of flags and return an FTD2XX
+        instance for it.
 
-        :param id_str:
+        :param id_str: ID string from listDevices
         :type id_str: str
         :param timeout: Time in seconds for read timeout. If timeout happens, read returns empty string.
         :type timeout: int
@@ -42,9 +43,10 @@ class MeComPhyFtdi(IntMeComPhy):
         :type baudrate: int
         :raises SerialException:
         :raises InstrumentConnectionError:
+        :return: None
         """
         id_str_bytes: bytes = id_str.encode()
-        self.ftdi = ftd2xx.openEx(id_str=id_str_bytes)
+        self.ftdi: FTD2XX = ftd2xx.openEx(id_str=id_str_bytes)
         self.ftdi.purge(mask=3)  # purges receive and transmit buffer in the device
         self.ftdi.setTimeouts(read=timeout * 1000, write=timeout * 1000)
 

--- a/src/mecompyapi/tec1090series.py
+++ b/src/mecompyapi/tec1090series.py
@@ -4,13 +4,14 @@ import time
 import datetime
 import statistics
 from enum import Enum
-from typing import Tuple, List, Optional
+from typing import Tuple, List, Optional, Union
 
 from mecompyapi.mecom_core.mecom_query_set import MeComQuerySet
 from mecompyapi.mecom_core.mecom_basic_cmd import MeComBasicCmd
 from mecompyapi.mecom_core.com_command_exception import ComCommandException
 
-from mecompyapi.phy_wrapper.mecom_phy_serial_port import MeComPhySerialPort, InstrumentException, ResponseTimeout
+from mecompyapi.phy_wrapper.mecom_phy_serial_port import MeComPhySerialPort, InstrumentException
+from mecompyapi.phy_wrapper.mecom_phy_ftdi import MeComPhyFtdi
 
 from mecompyapi.mecom_tec.lookup_table.lut_cmd import LutCmd
 from mecompyapi.mecom_tec.lookup_table.lut_status import LutStatus
@@ -118,14 +119,14 @@ class MeerstetterTEC(object):
     ./meerstetter/pyMeCom/mecom/commands.py
     """
     def __init__(self, *args, **kwargs) -> None:
-        self.phy_com = MeComPhySerialPort()
+        self.phy_com = None  # type: Optional[Union[MeComPhySerialPort, MeComPhyFtdi]]
         self.mequery_set = None  # type: Optional[MeComQuerySet]
         self.mecom_basic_cmd = None  # type: Optional[MeComBasicCmd]
         self.mecom_lut_cmd = None  # type: Optional[LutCmd]
         self.address = None  # type: Optional[int]
         self.instance = None  # type: Optional[int]
 
-    def connect(self, port: str = "COM9", instance: int = 1):
+    def connect_serial_port(self, port: str = "COM9", instance: int = 1):
         """
         Connects to a serial port. On Windows, these are typically 'COMX' where X
         is the number of the port. In Linux, they are often /dev/ttyXXXY where XXX
@@ -143,11 +144,36 @@ class MeerstetterTEC(object):
         :type instance: int
         :return: None
         """
+        self.phy_com = MeComPhySerialPort()
+
         self.instance = instance
         self.phy_com.connect(port_name=port)
         mequery_set = MeComQuerySet(phy_com=self.phy_com)
         self.mecom_basic_cmd = MeComBasicCmd(mequery_set=mequery_set)
         self.mecom_lut_cmd = LutCmd(mecom_query_set=mequery_set)
+        retries = 3
+        for _ in range(retries):
+            try:
+                self.address = self.get_device_address()
+                logging.debug(f"connected to {self.address}")
+                return
+            except ComCommandException as e:
+                logging.debug(f"[ComCommandException] : {e}")
+                continue
+        raise InstrumentException(f"Could not successfully query the controller address after {retries} retries...")
+
+    def connect_ftdi(self, id_str: str = "DK0E1IDC", instance: int = 1):
+        """
+
+        """
+        self.phy_com = MeComPhyFtdi()
+
+        self.instance = instance
+        self.phy_com.connect(id_str=id_str)
+        mequery_set = MeComQuerySet(phy_com=self.phy_com)
+        self.mecom_basic_cmd = MeComBasicCmd(mequery_set=mequery_set)
+        self.mecom_lut_cmd = LutCmd(mecom_query_set=mequery_set)
+
         retries = 3
         for _ in range(retries):
             try:

--- a/src/mecompyapi/tec1090series.py
+++ b/src/mecompyapi/tec1090series.py
@@ -164,7 +164,13 @@ class MeerstetterTEC(object):
 
     def connect_ftdi(self, id_str: str = "DK0E1IDC", instance: int = 1):
         """
+        Connect to the controller using the FTDI chip drivers.
 
+        :param id_str:
+        :type id_str: str
+        :param instance:
+        :type instance: int
+        :return: None
         """
         self.phy_com = MeComPhyFtdi()
 


### PR DESCRIPTION
The library now allows for connecting to the Meerstetter controller using the FTDI drivers. The feature has been tested and works as intended.