### PR TITLE
mecom_phy_ftdi.py module updated to connect to FTDI device using ID string or Device ID

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.10 (MeComPyAPI)" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (MeComPyAPI)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="6f6d24ee-0e50-4136-ad46-6aaadc2ff813" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/examples/monitor_data_logger.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/mecompyapi/tec1090series.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/mecompyapi/tec1090series.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -43,34 +41,6 @@
     &quot;settings.editor.selected.configurable&quot;: &quot;com.jetbrains.python.configuration.PyActiveSdkModuleConfigurable&quot;
   }
 }</component>
-  <component name="RunManager">
-    <configuration name="monitor_data_logger" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
-      <module name="MeComPyAPI" />
-      <option name="INTERPRETER_OPTIONS" value="" />
-      <option name="PARENT_ENVS" value="true" />
-      <envs>
-        <env name="PYTHONUNBUFFERED" value="1" />
-      </envs>
-      <option name="SDK_HOME" value="" />
-      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/examples" />
-      <option name="IS_MODULE_SDK" value="true" />
-      <option name="ADD_CONTENT_ROOTS" value="true" />
-      <option name="ADD_SOURCE_ROOTS" value="true" />
-      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/examples/monitor_data_logger.py" />
-      <option name="PARAMETERS" value="" />
-      <option name="SHOW_COMMAND_LINE" value="false" />
-      <option name="EMULATE_TERMINAL" value="false" />
-      <option name="MODULE_MODE" value="false" />
-      <option name="REDIRECT_INPUT" value="false" />
-      <option name="INPUT_FILE" value="" />
-      <method v="2" />
-    </configuration>
-    <recent_temporary>
-      <list>
-        <item itemvalue="Python.monitor_data_logger" />
-      </list>
-    </recent_temporary>
-  </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="Default task">

--- a/examples/connect_ftdi.py
+++ b/examples/connect_ftdi.py
@@ -1,6 +1,4 @@
-import time
 import logging
-import ftd2xx
 from mecompyapi.tec1090series import MeerstetterTEC
 
 

--- a/examples/connect_serial_port.py
+++ b/examples/connect_serial_port.py
@@ -1,4 +1,3 @@
-import time
 import logging
 from mecompyapi.tec1090series import MeerstetterTEC
 

--- a/examples/download_lookup_table.py
+++ b/examples/download_lookup_table.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     # initialize controller
     mc = MeerstetterTEC()
 
-    mc.connect(port="COM13")
+    mc.connect_serial_port(port="COM13")
 
     identity = mc.get_id()
     print("identity: {}".format(identity))

--- a/examples/execute_lookup_table.py
+++ b/examples/execute_lookup_table.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     mc = MeerstetterTEC()
 
     try:
-        mc.connect(port="COM13")
+        mc.connect_serial_port(port="COM13")
 
         if mc.get_lookup_table_status() == LutStatus.EXECUTING:
             mc.stop_lookup_table()

--- a/examples/monitor_data_logger.py
+++ b/examples/monitor_data_logger.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
     # initialize controller
     mc = MeerstetterTEC()
 
-    mc.connect(port="COM13")
+    mc.connect_serial_port(port="COM13")
 
     identity = mc.get_id()
     print(f"identity: {identity}")

--- a/examples/set_auto_save_to_flash.py
+++ b/examples/set_auto_save_to_flash.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
     # initialize controller
     mc = MeerstetterTEC()
 
-    mc.connect(port="COM13")
+    mc.connect_serial_port(port="COM13")
 
     identity = mc.get_id()
     print("identity: {}".format(identity))

--- a/src/mecompyapi/mecom_core/mecom_basic_cmd.py
+++ b/src/mecompyapi/mecom_core/mecom_basic_cmd.py
@@ -16,7 +16,7 @@ class MeComBasicCmd:
         :param mequery_set: Reference to the communication interface.
         :type mequery_set: MeComQuerySet
         """
-        self.mequery_set = mequery_set
+        self.mequery_set: MeComQuerySet = mequery_set
 
         # self.address = self.get_device_address()
 
@@ -36,12 +36,12 @@ class MeComBasicCmd:
         :return:
         :rtype: int
         """
-        tx_frame = MeComPacket(control="#", address=0)
+        tx_frame: MeComPacket = MeComPacket(control="#", address=0)
         address_str: str = tx_frame.payload
         address: int = int(address_str)
         return address
 
-    def reset_device(self, address: int, channel: int):
+    def reset_device(self, address: int, channel: int) -> None:
         """
         Resets the device.
         Usually the device does answer to this command, because the reset is slightly delayed.
@@ -52,10 +52,11 @@ class MeComBasicCmd:
         :param channel: TEC output channel (i.e. Parameter Instance)
         :type channel: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
+        :return: None
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "RS")
             self.mequery_set.set(tx_frame)
         except Exception as e:
@@ -73,12 +74,12 @@ class MeComBasicCmd:
         :return: Device Identification String. Usually 20 Chars long.
         :rtype: str
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "?IF")
             tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, channel)
-            rx_frame = self.mequery_set.query(tx_frame=tx_frame)
+            rx_frame: MeComPacket = self.mequery_set.query(tx_frame=tx_frame)
             return rx_frame.payload
         except Exception as e:
             raise ComCommandException(f"Get Identification String failed: {e}")
@@ -100,18 +101,18 @@ class MeComBasicCmd:
         :return: Returned value.
         :rtype: int
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "?VR")
             tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
             tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
-            rx_frame = self.mequery_set.query(tx_frame=tx_frame)
+            rx_frame: MeComPacket = self.mequery_set.query(tx_frame=tx_frame)
             return mecom_var_convert.read_int32(rx_frame.payload)
         except Exception as e:
             raise ComCommandException(f"Get INT32 Value failed: {e}")
 
-    def get_float_value(self, address: int, parameter_id: int, instance: int):
+    def get_float_value(self, address: int, parameter_id: int, instance: int) -> float:
         """
         Returns a float 32Bit value from the device.
 
@@ -123,20 +124,20 @@ class MeComBasicCmd:
         :type instance: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         :return: Returned value.
-        :rtype:
+        :rtype: float
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "?VR")
             tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
             tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
-            rx_frame = self.mequery_set.query(tx_frame=tx_frame)
+            rx_frame: MeComPacket = self.mequery_set.query(tx_frame=tx_frame)
             return mecom_var_convert.read_float32(rx_frame.payload)
         except Exception as e:
             raise ComCommandException(f"Get FLOAT Value failed: {e}")
 
-    def get_double_value(self, address: int, parameter_id: int, instance: int):
+    def get_double_value(self, address: int, parameter_id: int, instance: int) -> str:
         """
         Returns a double 64Bit value from the device.
 
@@ -148,20 +149,20 @@ class MeComBasicCmd:
         :type instance: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         :return: Returned value.
-        :rtype:
+        :rtype: str
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "?VR")
             tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
             tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
-            rx_frame = self.mequery_set.query(tx_frame=tx_frame)
+            rx_frame: MeComPacket = self.mequery_set.query(tx_frame=tx_frame)
             return rx_frame.payload
         except Exception as e:
             raise ComCommandException(f"Get DOUBLE Value failed: {e}")
 
-    def get_int64_value(self, address: int, parameter_id: int, instance: int):
+    def get_int64_value(self, address: int, parameter_id: int, instance: int) -> str:
         """
         Returns a signed int 64Bit value from the device.
 
@@ -173,20 +174,20 @@ class MeComBasicCmd:
         :type instance: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         :return: Returned value.
-        :rtype:
+        :rtype: str
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "?VR")
             tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
             tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
-            rx_frame = self.mequery_set.query(tx_frame=tx_frame)
+            rx_frame: MeComPacket = self.mequery_set.query(tx_frame=tx_frame)
             return rx_frame.payload
         except Exception as e:
             raise ComCommandException(f"Get INT64 Value failed: {e}")
 
-    def set_int32_value(self, address: int, parameter_id: int, instance: int, value: int):
+    def set_int32_value(self, address: int, parameter_id: int, instance: int, value: int) -> MeComPacket:
         """
         Sets a signed int 32Bit value to the device.
 
@@ -200,21 +201,23 @@ class MeComBasicCmd:
         :type value: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "VS")
             tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
             tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
             tx_frame.payload = mecom_var_convert.add_int32(tx_frame.payload, value)
-            rx_frame = self.mequery_set.set(tx_frame=tx_frame)
+            rx_frame: MeComPacket = self.mequery_set.set(tx_frame=tx_frame)
             return rx_frame
 
         except Exception as e:
-            raise ComCommandException(f"Set INT32 Value failed: Address: {address}; "
-                                      f"ID: {parameter_id}; Detail: {instance} : {e}")
+            raise ComCommandException(
+                f"Set INT32 Value failed: Address: {address}; "
+                f"ID: {parameter_id}; Detail: {instance} : {e}"
+            )
 
-    def set_int64_value(self, address: int, parameter_id: int, instance: int, value: int):
+    def set_int64_value(self, address: int, parameter_id: int, instance: int, value: int) -> MeComPacket:
         """
         Sets a signed int 64Bit value to the device.
 
@@ -228,21 +231,23 @@ class MeComBasicCmd:
         :type value: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "VS")
             tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
             tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
             tx_frame.payload = mecom_var_convert.add_int64(tx_frame.payload, value)
-            rx_frame = self.mequery_set.set(tx_frame=tx_frame)
+            rx_frame: MeComPacket = self.mequery_set.set(tx_frame=tx_frame)
             return rx_frame
 
         except Exception as e:
-            raise ComCommandException(f"Set INT64 Value failed: Address: {address}; "
-                                      f"ID: {parameter_id}; Detail: {instance} : {e}")
+            raise ComCommandException(
+                f"Set INT64 Value failed: Address: {address}; "
+                f"ID: {parameter_id}; Detail: {instance} : {e}"
+            )
 
-    def set_float_value(self, address: int, parameter_id: int, instance: int, value: float):
+    def set_float_value(self, address: int, parameter_id: int, instance: int, value: float) -> MeComPacket:
         """
         Sets a float 32Bit value to the device.
 
@@ -256,21 +261,23 @@ class MeComBasicCmd:
         :type value: float
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "VS")
             tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
             tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
             tx_frame.payload = mecom_var_convert.add_float32(tx_frame.payload, value)
-            rx_frame = self.mequery_set.set(tx_frame=tx_frame)
+            rx_frame: MeComPacket = self.mequery_set.set(tx_frame=tx_frame)
             return rx_frame
 
         except Exception as e:
-            raise ComCommandException(f"Set FLOAT32 Value failed: Address: {address}; "
-                                      f"ID: {parameter_id}; Detail: {instance} : {e}")
+            raise ComCommandException(
+                f"Set FLOAT32 Value failed: Address: {address}; "
+                f"ID: {parameter_id}; Detail: {instance} : {e}"
+            )
 
-    def set_double_value(self, address: int, parameter_id: int, instance: int, value: int):
+    def set_double_value(self, address: int, parameter_id: int, instance: int, value: int) -> MeComPacket:
         """
         Sets a double 64Bit value to the device.
 
@@ -284,21 +291,25 @@ class MeComBasicCmd:
         :type value: int
         :raises ComCommandException: When the command fails. Check the inner exception for details.
         """
-        mecom_var_convert = MeComVarConvert()
+        mecom_var_convert: MeComVarConvert = MeComVarConvert()
         try:
-            tx_frame = MeComPacket(control="#", address=address)
+            tx_frame: MeComPacket = MeComPacket(control="#", address=address)
             tx_frame.payload = mecom_var_convert.add_string(tx_frame.payload, "VS")
             tx_frame.payload = mecom_var_convert.add_uint16(tx_frame.payload, parameter_id)
             tx_frame.payload = mecom_var_convert.add_uint8(tx_frame.payload, instance)
             tx_frame.payload = mecom_var_convert.add_double64(tx_frame.payload, value)
-            rx_frame = self.mequery_set.set(tx_frame=tx_frame)
+            rx_frame: MeComPacket = self.mequery_set.set(tx_frame=tx_frame)
             return rx_frame
 
         except Exception as e:
-            raise ComCommandException(f"Set DOUBLE64 Value failed: Address: {address}; "
-                                      f"ID: {parameter_id}; Detail: {instance} : {e}")
+            raise ComCommandException(
+                f"Set DOUBLE64 Value failed: Address: {address}; "
+                f"ID: {parameter_id}; Detail: {instance} : {e}"
+            )
 
-    def set_device_address(self, address: int, device_type: int, serial_number: str, set_address: int, option: int):
+    def set_device_address(
+            self, address: int, device_type: int, serial_number: str, set_address: int, option: int
+    ):
         """
         Sets a signed int 64Bit value to the device.
 
@@ -316,7 +327,9 @@ class MeComBasicCmd:
         """
         raise NotImplementedError
 
-    def get_limits(self, address: int, parameter_id: int, instance: int, min_: float, max_: float):
+    def get_limits(
+            self, address: int, parameter_id: int, instance: int, min_: float, max_: float
+    ):
         """
         Returns the basic Meta data to the parameter.
 
@@ -338,26 +351,28 @@ class MeComBasicCmd:
 
 
 if __name__ == "__main__":
-    phy_com = MeComPhySerialPort()
+    phy_com: MeComPhySerialPort = MeComPhySerialPort()
     phy_com.connect(port_name="COM9")
 
-    mequery_set_ = MeComQuerySet(phy_com=phy_com)
+    mequery_set_: MeComQuerySet = MeComQuerySet(phy_com=phy_com)
 
-    mecom_basic_cmd = MeComBasicCmd(mequery_set=mequery_set_)
+    mecom_basic_cmd: MeComBasicCmd = MeComBasicCmd(mequery_set=mequery_set_)
 
-    identify = mecom_basic_cmd.get_ident_string(address=2, channel=1)
+    identify: str = mecom_basic_cmd.get_ident_string(address=2, channel=1)
     print(f"identify : {identify}")
     print(f"type(identify) : {type(identify)}")
     print("\n", end="")
 
-    device_type_ = mecom_basic_cmd.get_int32_value(address=2, parameter_id=100,
-                                                   instance=1)  # parameter_name : "Device Type"
+    device_type_: int = mecom_basic_cmd.get_int32_value(
+        address=2, parameter_id=100, instance=1
+    )  # parameter_name : "Device Type"
     print(f"device_type : {device_type_}")
     print(f"type(device_type) : {type(device_type_)}")
     print("\n", end="")
 
-    object_temperature = mecom_basic_cmd.get_float_value(address=2, parameter_id=1000,
-                                                         instance=1)  # parameter_name : "Object Temperature"
+    object_temperature: float = mecom_basic_cmd.get_float_value(
+        address=2, parameter_id=1000, instance=1
+    )  # parameter_name : "Object Temperature"
     print(f"object_temperature : {object_temperature}")
     print(f"type(object_temperature) : {type(object_temperature)}")
     print("\n", end="")

--- a/src/mecompyapi/mecom_core/mecom_frame.py
+++ b/src/mecompyapi/mecom_core/mecom_frame.py
@@ -89,10 +89,11 @@ class MeComFrame:
     Handles the communication Frame level of the Meerstetter Engineering GmbH
     Communication protocol.
     """
+
     def __init__(self, int_phy_com: MeComPhySerialPort, statistics: Optional = None):
         """
         Saves the needed interface internally for further use.
-        
+
         :param int_phy_com: Interface to the physical interface.
         :type int_phy_com: MeComPhySerialPort
         :param statistics: Reference to the Statistics module.
@@ -105,10 +106,10 @@ class MeComFrame:
 
     def send_frame(self, tx_frame: MeComPacket) -> None:
         """
-        Serializes the given Data structure to a proper 
-        frame and sends it to the physical interface. 
+        Serializes the given Data structure to a proper
+        frame and sends it to the physical interface.
         It returns immediately.
-        
+
         :param tx_frame: Data to send.
         :type tx_frame: MeComPacket
         :raises MeComPhyInterfaceException:
@@ -126,7 +127,7 @@ class MeComFrame:
 
         tx_stream += tx_frame.payload
 
-        self.last_crc = self._calc_crc_citt(frame=tx_stream.encode())
+        self.last_crc: int = self._calc_crc_citt(frame=tx_stream.encode())
 
         tx_stream = mecom_var_convert.add_uint16(stream=tx_stream, value=self.last_crc)
 
@@ -142,7 +143,7 @@ class MeComFrame:
         :return: Received data.
         :rtype: MeComPacket
         """
-        rx_frame = MeComPacket()
+        rx_frame: MeComPacket = MeComPacket()
         rx_frame.receive_type = ERcvType.EMPTY
 
         rx_stream: str = self.phy_com.get_data_or_timeout()
@@ -151,7 +152,9 @@ class MeComFrame:
 
         return rx_frame
 
-    def _decode_frame(self, rx_frame: MeComPacket, rx_stream: str, local_rx_buf: Optional = None) -> MeComPacket:
+    def _decode_frame(
+            self, rx_frame: MeComPacket, rx_stream: str, local_rx_buf: Optional = None
+    ) -> MeComPacket:
         """
 
         :param rx_frame:

--- a/src/mecompyapi/phy_wrapper/mecom_phy_ftdi.py
+++ b/src/mecompyapi/phy_wrapper/mecom_phy_ftdi.py
@@ -1,5 +1,9 @@
+import logging
+import time
+from typing import Optional
+
 import ftd2xx
-from ftd2xx import FTD2XX
+from ftd2xx import FTD2XX, defines
 
 from mecompyapi.phy_wrapper.int_mecom_phy import (
     IntMeComPhy, MeComPhyInterfaceException, MeComPhyTimeoutException
@@ -12,71 +16,93 @@ class MeComPhyFtdi(IntMeComPhy):
     """
     def __init__(self):
         """
-        Implements the IMeComPhy interface for the FTDI chip drivers.        
+        Implements the IMeComPhy interface for the FTDI chip drivers.
         """
         super().__init__()
-        self.ftdi = None
+        self.ftdi: Optional[FTD2XX] = None
 
-    def mecom_set_default_settings(self, baudrate: int):
+    def mecom_set_default_settings(self, baudrate: int, timeout: int):
         """
         Initializes the FTDI default settings, so that is it usually running
         with Meerstetter products.
 
         This function is not part of the IMeComPhy interface.
-        
+
         :param baudrate: Baud Rate for the Serial Interface.
         :type baudrate: int
+        :param timeout: Time in seconds for read timeout. If timeout happens, read returns empty string.
+        :type timeout: int
         """
-        raise NotImplementedError
+        self.ftdi.setBaudRate(baud=baudrate)
+        self.ftdi.setDataCharacteristics(
+            wordlen=defines.BITS_8, stopbits=defines.STOP_BITS_1, parity=defines.PARITY_NONE
+        )
+        self.ftdi.setFlowControl(flowcontrol=defines.FLOW_NONE, xon=0, xoff=0)
+        self.ftdi.setTimeouts(read=timeout * 1000, write=timeout * 1000)
+        self.ftdi.setLatencyTimer(latency=3)
+        # Purges receive and transmit buffer in the device
+        self.ftdi.purge(mask=defines.PURGE_RX | defines.PURGE_TX)
 
-    def connect(self, id_str: str, timeout: int = 1, baudrate: int = 57600) -> None:
+    def connect(
+            self, id_str: Optional[str] = None, dev_id: int = 0, baudrate: int = 57_600, timeout: int = 1
+    ) -> None:
         """
         Open a handle to an usb device by serial number(default), description or
         location(Windows only) depending on value of flags and return an FTD2XX
         instance for it.
 
         :param id_str: ID string from listDevices
-        :type id_str: str
-        :param timeout: Time in seconds for read timeout. If timeout happens, read returns empty string.
-        :type timeout: int
+        :type id_str: Optional[str]
+        :param dev_id:
+        :type dev_id: int
         :param baudrate: The baud rate setting.
         :type baudrate: int
+        :param timeout: Time in seconds for read timeout. If timeout happens, read returns empty string.
+        :type timeout: int
         :raises SerialException:
         :raises InstrumentConnectionError:
         :return: None
         """
-        id_str_bytes: bytes = id_str.encode()
-        self.ftdi: FTD2XX = ftd2xx.openEx(id_str=id_str_bytes)
-        self.ftdi.purge(mask=3)  # purges receive and transmit buffer in the device
-        self.ftdi.setTimeouts(read=timeout * 1000, write=timeout * 1000)
+        if id_str is not None:
+            id_str_bytes: bytes = id_str.encode()
+            self.ftdi: FTD2XX = ftd2xx.openEx(id_str=id_str_bytes)
+        else:
+            self.ftdi: FTD2XX = ftd2xx.open(dev=dev_id)
 
-    def tear(self):
+        self.mecom_set_default_settings(baudrate=baudrate, timeout=timeout)
+
+    def tear(self) -> None:
         """
         Tear should always be called when the instrument is being disconnected. It should
         also be called when the program is ending.
+
+        :return: None
         """
-        self.ftdi.purge(mask=3)  # purges receive and transmit buffer in the device
+        # Purges receive and transmit buffer in the device
+        self.ftdi.purge(mask=defines.PURGE_RX | defines.PURGE_TX)
         self.ftdi.close()
 
-    def send_string(self, stream: str):
+    def send_string(self, stream: str) -> None:
         """
         Sends data to the physical interface.
 
         :param stream: The whole content of the Stream is sent to the physical interface.
         :type stream: str
+        :return: None
         """
-        self.ftdi.purge(mask=3)  # purges receive and transmit buffer in the device
+        # Purges receive and transmit buffer in the device
+        self.ftdi.purge(mask=defines.PURGE_RX | defines.PURGE_TX)
 
-        stream_bytes = stream.encode()
+        stream_bytes: bytes = stream.encode()
 
         self.ftdi.write(data=stream_bytes)
 
-    def get_data_or_timeout(self):
+    def get_data_or_timeout(self) -> str:
         """
         Tries to read data from the physical interface or throws a timeout exception.
 
-        Reads the available data in the physical interface buffer and returns immediately. 
-        If the receiving buffer is empty, it tries to read at least one byte. 
+        Reads the available data in the physical interface buffer and returns immediately.
+        If the receiving buffer is empty, it tries to read at least one byte.
         It will wait till the timeout occurs if nothing is received.
         Must probably be called several times to receive the whole frame.
 
@@ -84,20 +110,24 @@ class MeComPhyFtdi(IntMeComPhy):
             is not OK.
         :raises MeComPhyTimeoutException: Thrown when 0 bytes were received during the
             specified timeout time.
+        :return:
+        :rtype: str
         """
+        # Wait for FTDI receive queue to receive characters from the instrument
+        time.sleep(0.1)
+        num_bytes_available: int = self.ftdi.getQueueStatus()
+        logging.debug(f"num_bytes_available : {num_bytes_available}")
         try:
-            # initialize response and carriage return
-            cr = "\r".encode()
-            response_frame = b''
-            response_byte = self.ftdi.read(nchars=1)  # read one byte at a time, timeout is set on instance level
-
-            # read until stop byte
-            while response_byte != cr:
-                response_frame += response_byte
-                response_byte = self.ftdi.read(nchars=1)
-
+            to_read: int = 1 if num_bytes_available == 0 else num_bytes_available
+            read_bytes: bytes = self.ftdi.read(nchars=to_read)
+            logging.debug(f"read_bytes : {read_bytes}")
+            if read_bytes == b"":
+                raise MeComPhyTimeoutException("The FTDI queue returned an empty byte.")
+            response_frame: bytes = read_bytes.rstrip(b"\r")
+            logging.debug(f"response_frame : {response_frame}")
             return response_frame.decode()
-
+        except MeComPhyTimeoutException as e:
+            raise e
         except Exception as e:
             raise MeComPhyInterfaceException(f"Failure during receiving: {e}")
 


### PR DESCRIPTION
The "connect()" method in the "mecom_phy_ftdi.py" module has been updated to accept either the ID string or Device ID when connecting to the FTDI chip.