### PR TITLE
Successfully handling the ftd2xx import exception in mecom_phy_ftdi.py

### DIFF
--- a/.idea/MeComPyAPI.iml
+++ b/.idea/MeComPyAPI.iml
@@ -5,7 +5,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.11 (MeComPyAPI)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.10 (MeComPyAPI)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (MeComPyAPI)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (MeComPyAPI)" project-jdk-type="Python SDK" />
 </project>

--- a/examples/get_object_temperature.py
+++ b/examples/get_object_temperature.py
@@ -1,5 +1,5 @@
 import logging
-from mecompyapi.tec import MeerstetterTEC
+from mecompyapi.tec import MeerstetterTEC, SaveToFlashState
 
 
 if __name__ == '__main__':
@@ -9,10 +9,11 @@ if __name__ == '__main__':
     # initialize controller
     mc = MeerstetterTEC()
 
-    # mc.connect_serial_port(port="COM9")
     mc.connect_serial_port(port="/dev/tec")
 
     identity = mc.get_id()
     logging.info(f"identity: {identity}")
+
+    logging.info(f"get_temperature : {mc.get_temperature()}")
 
     mc.tear()

--- a/examples/query_all_settings.py
+++ b/examples/query_all_settings.py
@@ -10,7 +10,8 @@ if __name__ == "__main__":
     # initialize controller
     mc = MeerstetterTEC()
 
-    mc.connect_serial_port(port="COM9")
+    # mc.connect_serial_port(port="COM9")
+    mc.connect_serial_port(port="/dev/tec")
 
     identity = mc.get_id()
     logging.info(f"identity: {identity}\n")

--- a/examples/set_integration_time.py
+++ b/examples/set_integration_time.py
@@ -1,5 +1,5 @@
 import logging
-from mecompyapi.tec import MeerstetterTEC
+from mecompyapi.tec import MeerstetterTEC, SaveToFlashState
 
 
 if __name__ == '__main__':
@@ -9,10 +9,17 @@ if __name__ == '__main__':
     # initialize controller
     mc = MeerstetterTEC()
 
-    # mc.connect_serial_port(port="COM9")
     mc.connect_serial_port(port="/dev/tec")
 
     identity = mc.get_id()
     logging.info(f"identity: {identity}")
+
+    mc.set_automatic_save_to_flash(save_to_flash=SaveToFlashState.ENABLED)
+
+    mc.set_integration_time(int_time_sec=4.8)
+
+    logging.info(f"get_proportional_gain : {mc.get_proportional_gain()}")
+
+    mc.set_automatic_save_to_flash(save_to_flash=SaveToFlashState.DISABLED)
 
     mc.tear()

--- a/examples/set_proportional_gain.py
+++ b/examples/set_proportional_gain.py
@@ -1,5 +1,5 @@
 import logging
-from mecompyapi.tec import MeerstetterTEC
+from mecompyapi.tec import MeerstetterTEC, SaveToFlashState
 
 
 if __name__ == '__main__':
@@ -9,10 +9,17 @@ if __name__ == '__main__':
     # initialize controller
     mc = MeerstetterTEC()
 
-    # mc.connect_serial_port(port="COM9")
     mc.connect_serial_port(port="/dev/tec")
 
     identity = mc.get_id()
     logging.info(f"identity: {identity}")
+
+    # mc.set_automatic_save_to_flash(save_to_flash=SaveToFlashState.ENABLED)
+
+    mc.set_proportional_gain(prop_gain=8.1)
+
+    logging.info(f"get_proportional_gain : {mc.get_proportional_gain()}")
+
+    # mc.set_automatic_save_to_flash(save_to_flash=SaveToFlashState.DISABLED)
 
     mc.tear()

--- a/src/mecompyapi/example.py
+++ b/src/mecompyapi/example.py
@@ -1,41 +1,47 @@
 import logging
 
 from mecompyapi.mecom_core.mecom_basic_cmd import MeComBasicCmd
+from mecompyapi.mecom_core.mecom_frame import MeComPacket
 from mecompyapi.mecom_core.mecom_query_set import MeComQuerySet
 from mecompyapi.phy_wrapper.mecom_phy_serial_port import MeComPhySerialPort
 
 
 if __name__ == "__main__":
     # start logging
-    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s:%(module)s:%(levelname)s:%(message)s")
+    logging.basicConfig(
+        level=logging.DEBUG, format="%(asctime)s:%(module)s:%(levelname)s:%(message)s"
+    )
 
-    phy_com = MeComPhySerialPort()
+    phy_com: MeComPhySerialPort = MeComPhySerialPort()
     phy_com.connect(port_name="COM9")
 
-    mequery_set = MeComQuerySet(phy_com=phy_com)
+    mequery_set: MeComQuerySet = MeComQuerySet(phy_com=phy_com)
 
-    mecom_basic_cmd = MeComBasicCmd(mequery_set=mequery_set)
+    mecom_basic_cmd: MeComBasicCmd = MeComBasicCmd(mequery_set=mequery_set)
 
-    identify = mecom_basic_cmd.get_ident_string(address=2, channel=1)
+    identify: str = mecom_basic_cmd.get_ident_string(address=2, channel=1)
     logging.info(f"identify : {identify}")
 
-    device_type = mecom_basic_cmd.get_int32_value(
-        address=2, parameter_id=100, instance=1
+    device_type: int = (
+        mecom_basic_cmd.get_int32_value(
+            address=2, parameter_id=100, instance=1)
     )  # parameter_name : "Device Type"
     logging.info(f"device_type : {device_type}")
 
-    target_object_temperature = (
+    target_object_temperature: float = (
         mecom_basic_cmd.get_float_value(address=2, parameter_id=1010, instance=1)
     )  # parameter_name : "Target Object Temperature"
     logging.info(f"target_object_temperature : {target_object_temperature}")
 
-    object_temperature = mecom_basic_cmd.get_float_value(
-        address=2, parameter_id=1000, instance=1
+    object_temperature: float = (
+        mecom_basic_cmd.get_float_value(
+            address=2, parameter_id=1000, instance=1)
     )  # parameter_name : "Object Temperature"
     logging.info(f"object_temperature : {object_temperature}")
 
-    rx_frame = mecom_basic_cmd.set_float_value(
-        address=2, parameter_id=3000, instance=1, value=27.0
+    rx_frame: MeComPacket = (
+        mecom_basic_cmd.set_float_value(
+            address=2, parameter_id=3000, instance=1, value=27.0)
     )  # parameter_name : "Target Object Temp (Set)"
     logging.info(f"{rx_frame.receive_type}")
 

--- a/src/mecompyapi/tec.py
+++ b/src/mecompyapi/tec.py
@@ -149,8 +149,8 @@ class MeerstetterTEC(object):
         self.phy_com: MeComPhySerialPort = MeComPhySerialPort()
         self.phy_com.connect(port_name=port)
 
-        mequery_set = MeComQuerySet(phy_com=self.phy_com)
-        self.mecom_basic_cmd = MeComBasicCmd(mequery_set=mequery_set)
+        mequery_set: MeComQuerySet = MeComQuerySet(phy_com=self.phy_com)
+        self.mecom_basic_cmd: MeComBasicCmd = MeComBasicCmd(mequery_set=mequery_set)
 
         # Get Identification String
         fw_id_str: str = self.get_firmware_identification_string(broadcast=True)
@@ -158,10 +158,10 @@ class MeerstetterTEC(object):
 
         self.mecom_lut_cmd = LutCmd(mecom_query_set=mequery_set)
 
-        retries = 3
+        retries: int = 3
         for _ in range(retries):
             try:
-                self.address = self.get_device_address()
+                self.address: int = self.get_device_address()
                 logging.debug(f"connected to {self.address}")
                 return
             except ComCommandException as e:
@@ -266,8 +266,9 @@ class MeerstetterTEC(object):
         :rtype: int
         """
         logging.debug(f"get device type for channel {self.instance}")
-        device_type = self.mecom_basic_cmd.get_int32_value(
-            address=self.address, parameter_id=100, instance=self.instance
+        device_type: int = (
+            self.mecom_basic_cmd.get_int32_value(
+                address=self.address, parameter_id=100, instance=self.instance)
         )
         return device_type
 
@@ -279,7 +280,7 @@ class MeerstetterTEC(object):
         :rtype: int
         """
         logging.debug(f"get hardware version for channel {self.instance}")
-        hardware_version = self.mecom_basic_cmd.get_int32_value(
+        hardware_version: int = self.mecom_basic_cmd.get_int32_value(
             address=self.address, parameter_id=101, instance=self.instance
         )
         return hardware_version
@@ -292,7 +293,7 @@ class MeerstetterTEC(object):
         :rtype: int
         """
         logging.debug(f"get serial number for channel {self.instance}")
-        serial_number = self.mecom_basic_cmd.get_int32_value(
+        serial_number: int = self.mecom_basic_cmd.get_int32_value(
             address=self.address, parameter_id=102, instance=self.instance
         )
         return serial_number
@@ -1279,6 +1280,7 @@ class MeerstetterTEC(object):
             "firmware_version": self.get_firmware_version(),
             "device_status": self.get_device_status(),
             "object_temperature": self.get_temperature(),
+            "setpoint_temperature": self.get_setpoint_temperature(),
             "actual_output_current": self.get_tec_current(),
             "actual_output_voltage": self.get_tec_voltage(),
             "device_temperature": self.get_device_temperature(),


### PR DESCRIPTION
The exception raised when importing the ftd2xx unsuccessfully is now handled and warning message appears to alert the user. The user can now move forward using the pyserial library successfully.

Code styling improvements on several scripts were made. Also, new examples added to the examples folder.